### PR TITLE
Use explicit symbol names

### DIFF
--- a/src/pedestal_api/helpers.clj
+++ b/src/pedestal_api/helpers.clj
@@ -3,7 +3,7 @@
             [pedestal-api.swagger :as swagger]))
 
 (defmacro defhelper [helper-name]
-  `(do (defmacro ~(symbol (str "def" helper-name))
+  `(do (defmacro ~(symbol helper-name)
          [name# swagger# & args#]
          `(def ~name#
             (swagger/annotate ~swagger#
@@ -42,10 +42,10 @@
 ;;
 ;; All these forms create equivalent interceptors.
 
-(defhelper before)
-(defhelper after)
-(defhelper around)
-(defhelper on-request)
-(defhelper on-response)
-(defhelper handler)
-(defhelper middleware)
+(defhelper defbefore)
+(defhelper defafter)
+(defhelper defaround)
+(defhelper defon-request)
+(defhelper defon-response)
+(defhelper defhandler)
+(defhelper defmiddleware)


### PR DESCRIPTION
From the Clojure point of view nothing changes, but this helps some static analyzers, notably Cursive, which otherwise complains defhandler doesn't exist.